### PR TITLE
This fixes issues cherry-pick issues with missing code from 37a732

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,3 +147,24 @@
 ### Features
 * Enable the JUPYTERHUB_LOGIN_URL for login redirect
 * Default the display name to imagestream name
+
+## Release 0.5.0 (2021-07-08T11:22:03)
+### Features
+* Fix to save changes on env variable deletion (#164)
+* UI: Indicate notebooks are still being built (#163)
+* Handle multiple version of notebooks (#162)
+* Skip imagestreams which don't have any tags
+* Move buildstatus to ImageTagInfo
+* Fix the UI config for GPU number dropdown
+* Add segment key and clusterversion
+* Added a build_status value for each notebook image
+* Add default empty list before loop in tag_exists
+### Improvements
+* Added recommended tags and changed structure of images
+* Handle config load errors and config loading state
+
+## Release 0.5.1 (2021-07-13T08:35:31)
+### Features
+* Use the default tag if there is no prev or default image
+* Check for the empty status
+* Append tag name to the default image

--- a/jupyterhub_singleuser_profiles/api/swagger.yaml
+++ b/jupyterhub_singleuser_profiles/api/swagger.yaml
@@ -405,3 +405,14 @@ components:
       - name
       - content
       - recommended
+    Instance:
+      title: Instance
+      type: object
+      properties:
+        segment_key:
+          title: Segment key
+          type: string
+        cluster_id:
+          title: Cluster ID
+          type: string
+      

--- a/jupyterhub_singleuser_profiles/version.py
+++ b/jupyterhub_singleuser_profiles/version.py
@@ -2,4 +2,4 @@
 """jupyterhub-singleuser-profiles."""
 
 
-__version__ = "0.4.2"
+__version__ = "0.5.1"


### PR DESCRIPTION
This fixes issues cherry-pick issues with missing code from 37a732 in api/swagger.yaml.  This is the same commits from PR #29 rebased ontop of v1.0.17

Commits that were squashed
* Rebase
  (cherry picked from commit 37a732ee9183115ccc8ded2cc263562417d1b8a2)

* Merge pull request #157 from mroman-redhat/feature/telemetry-data
  Add an API call to gather information about the instance
  (cherry picked from commit 76eb0c5e77d470ddcb0964e17e1c26fc435c5393)

* Release of version 0.5.0
  (cherry picked from commit e4c3770c2fa27ef791f672f691bae951fdba2b9f)

* Release of version 0.5.1
  (cherry picked from commit 6687c65083952c779644e259988e14405007e1f2)