### PR TITLE
api.py: Fix NoneType exception when user is None

### DIFF
--- a/jupyterhub_singleuser_profiles/api/api.py
+++ b/jupyterhub_singleuser_profiles/api/api.py
@@ -47,10 +47,10 @@ def authenticated(f):
                 user = auth.user_for_token(token, use_cache=False)
         else:
             user = None
-        if for_user and user.get('admin'):
-            user['name'] = for_user
-            user['admin'] = False
         if user:
+            if for_user and user.get('admin'):
+                user['name'] = for_user
+                user['admin'] = False
             return f(user=user, *args, **kwargs)
         else:
             # redirect to login url on failed auth


### PR DESCRIPTION
Cherry pick of https://github.com/opendatahub-io/jupyterhub-singleuser-profiles/pull/196

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): [RHODS-1959](https://issues.redhat.com/browse/RHODS-1959)
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
