### PR TITLE
[UPSTREAM]Add a case for when node memory allocatable is in bytes

### DIFF
--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -156,6 +156,9 @@ class OpenShift(object):
       memory = float(memory_str[:-2])
     elif memory_str[-1:] == 'm':
       memory = float(memory_str[:-1])/1000000000000
+    else:
+      # Memory unit is bytes
+      memory = float(memory_str)/1000000000
     return memory
 
   def get_gpu_number(self):


### PR DESCRIPTION
In some cases we have seen where a node can report its allocatable
memory amount in bytes, with no unit specifier at the end. JSP does not
currenty support this case. When this happens, no notebook size options
are presented to the user and there is no ability to spawn a notebook.
This adds a case to the function to handle this.

This cherry-pick from upstream should additionally also solve this issue with OCP 4.9, since it will ignore the additional character in the memory value:
https://issues.redhat.com/browse/RHODS-2074

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2074 https://issues.redhat.com/browse/ODH-506
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
