### PR TITLE
Add check for cases when memory bytes appear with 'm' suffix

### DIFF
--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -154,6 +154,8 @@ class OpenShift(object):
       memory = float(memory_str[:-2])/1000
     elif memory_str[-2:] == 'Gi':
       memory = float(memory_str[:-2])
+    elif memory_str[-1:] == 'm':
+      memory = float(memory_str[:-1])/1000000000000
     return memory
 
   def get_gpu_number(self):


### PR DESCRIPTION
This is an additional PR to fix cases where memory values in nodes appear with a 'm' suffix, which means millibytes, and correctly divides the value into Gi.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-2074
- [x] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
