### PR TITLE
Added optin logic

### DIFF
--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -144,7 +144,9 @@ class SingleuserProfiles(object):
     return ui.validate_ui_cm()
   
   def get_instance(self):
-    segment_key = self.openshift.read_secret("rhods-segment-key")
+    segment_key_enabled = self.openshift.read_config_map("rhods-segment-key-config")
+    is_segment_enabled = segment_key_enabled.get("segmentKeyEnabled", "false") == "true"
+    segment_key = self.openshift.read_secret("rhods-segment-key") if is_segment_enabled else {}
     cluster_version = self.openshift.get_cluster_version("version")
     return {
       'segment_key': segment_key,


### PR DESCRIPTION
Signed-off-by: Lucas Fernandez <lferrnan@redhat.com>

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-871
- [X] The Jira story is acked
- [X] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

**THIS PR MUST BE FOLLOWED UP WITH AN UPDATE IN JUPYTERHUB-ODH UPDATING [ITS DEPENDENCIES](https://github.com/red-hat-data-services/jupyterhub-odh/blob/master/requirements-external.txt#L9)**

## Testing instructions
1. Deploy this PR with the [ODH-Dashboard PR](https://github.com/red-hat-data-services/odh-dashboard/pull/178).
2. Ensure both `segment-key-secret` secret and `rhods-segment-key-config` configmap are deployed in the apps Namespace.
3. Check that the `rhods-segment-key-config` is set to **true**.
4. Open jupyterhub, and when selecting the **notebook server**  inspect network, you should find a network call called `/instance` with the *write key*.
<img width="1728" alt="jupyterhub_false" src="https://user-images.githubusercontent.com/16117276/149492729-ab49e258-8005-401f-891d-88bac0f9be1d.png">

5. Additionally segment should be tracking the interaction.
6. Now change `rhods-segment-key-config` to **false**.
7. Reload jupyterhub and now `/instance` should be empty.
<img width="1728" alt="jupyterhub_true" src="https://user-images.githubusercontent.com/16117276/149492703-5378294d-7e33-4b04-a99d-535883b456ba.png">

