### PR TITLE
[UPSTREAM] Add check for cluster gpus before apply pod gpu config

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/src/SizesForm/SizesForm.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/SizesForm/SizesForm.tsx
@@ -76,6 +76,12 @@ const SizesForm: React.FC<ImageFormProps> = ({ uiConfig, userConfig }) => {
     }
   }, [sizeDescriptions, userConfig]);
 
+  React.useEffect(() => {
+    if (!uiConfig.gpuConfig?.enabled) {
+      postGPUChange(0);
+    }
+  }, [uiConfig])
+
   const sizeOptions = React.useMemo(() => {
     if (!sizeList?.length || !sizeDescriptions?.length) {
       return null;


### PR DESCRIPTION
Add cluster gpu check before applying the gpu config to the notebook pod spec

Testing instructions:
1. Deploy RHODS with no gpu nodes present
1. Login to JH and spawn a notebook to create a JH user profile ConfigMap that stores the last selected spawner values
1. Shutdown the user notebook
1. Manually edit the JH user profile ConfigMap to add a gpu value >0 to replicate the scenario where the previous user notebook pod had gpus attached
1. Login to the JH Spawner UI and confirm that there is no UI element for selecting gpu and attempt to spawn a notebook
1. Confirm that the user notebook pod is scheduled anddoes not request any gpus. `.spec.resources.limits['nvidia.com/gpu']` should not exist

You can verify that this does not break existing functionality with the following steps.
1. Deploy RHODS + GPU Operator
1. Add a GPU node to the cluster and wait for the gpu operator to enable the GPUs (gpu node has label `nvidia.com/gpu: X`)
1. Login to JH and spawn a notebook that requests a gpu
1. Wait for the notebook to spawn successfully and shut it down
1. Remove the GPU node from the cluster wait until there are no GPUs in the cluster
1. Go to the JH spawner and verify that there is no UI element for requesting GPUs and start any notebook
1. Confirm that the notebook pod spawns successfully with no GPUs requested

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s): [RHODS-3069](https://issues.redhat.com/browse/RHODS-3069)
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
