### PR TITLE
Fix Error message when reading Configmap

### DIFF
--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -58,7 +58,7 @@ class OpenShift(object):
       config_map = self.api_client.read_namespaced_config_map(config_map_name, notebook_namespace)
     except ApiException as e:
       if e.status != 404:
-        _LOGGER.error("Error reading a config map %s: %s" % (secret_name, e))
+        _LOGGER.error("Error reading a config map %s: %s" % (config_map_name, e))
       return result
 
     if key_name:


### PR DESCRIPTION
This commit fixes potential pod error when reading configmap in  `rhods-notebooks`  namespace

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [ ] JIRA link(s):
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
