### PR TITLE
Prevent disabled NB images from default selection in UI

### DIFF
--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageForm.tsx
@@ -97,7 +97,7 @@ const ImageForm: React.FC<ImageFormProps> = ({ userConfig, onValidImage }) => {
 
           // Default not set or not found, find the default tag and set it as selected
           const defaultImage = imageList.find(
-            (image) => image.tags?.find((tag) => tag.default) ?? false,
+            (image) => image.tags?.find((tag) => tag.default && isImageTagBuildValid(tag)) ?? false,
           );
           if (defaultImage) {
             const values = {

--- a/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageSelector.tsx
+++ b/jupyterhub_singleuser_profiles/ui/src/ImageForm/ImageSelector.tsx
@@ -57,7 +57,7 @@ const ImageSelector: React.FC<ImageSelectorProps> = ({
           </span>
         }
         description={getDescriptionForTag(currentTag)}
-        isChecked={image.name === selectedImage}
+        isChecked={image.name === selectedImage && disabled !== true ? true:false}
         onChange={(checked: boolean) => handleSelection(image, currentTag?.name || '', checked)}
       />
       <ImageVersions


### PR DESCRIPTION
Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): [RHODS-3183](https://issues.redhat.com/browse/RHODS-3183)
- [x] The Jira story is acked
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

Can be tested with the instructions and livebuild outlined in https://github.com/red-hat-data-services/jupyterhub-odh/pull/84