### PR TITLE
Add in a gpu node soft anti-affinity for pods that don't request GPUs

### DIFF
--- a/jupyterhub_singleuser_profiles/profiles.py
+++ b/jupyterhub_singleuser_profiles/profiles.py
@@ -29,6 +29,7 @@ class SingleuserProfiles(object):
     self.profiles = []
     self.namespace = None
     self.gpu_types = []
+    self.cpu_types = []
     self.gpu_mode = gpu_mode
 
     self.openshift = OpenShift(namespace=namespace, verify_ssl=verify_ssl)
@@ -53,6 +54,7 @@ class SingleuserProfiles(object):
   
   def load_profiles(self, secret_name="jupyter-singleuser-profiles", filename=None, key_name="jupyterhub-singleuser-profiles.yaml", username=None):
     self.gpu_types = []
+    self.cpu_types = []
     self.profiles = []
     self.sizes = []
     self.ui = {}
@@ -63,6 +65,7 @@ class SingleuserProfiles(object):
         config_map_yaml = self.openshift.read_config_map(cm_name, key_name)
         if config_map_yaml:
           self.gpu_types.extend(config_map_yaml.get("gpuTypes", []))
+          self.cpu_types.extend(config_map_yaml.get("gpuTypes", []))
           self.sizes.extend(config_map_yaml.get("sizes", []))
           self.profiles.extend(config_map_yaml.get("profiles", [self.empty_profile()]))
           self.ui = {**self.ui, **config_map_yaml.get("ui", {})}
@@ -173,6 +176,9 @@ class SingleuserProfiles(object):
   def get_gpu_types(self):
     return self.gpu_types
 
+  def get_cpu_types(self):
+    return self.cpu_types
+
   @classmethod
   def empty_profile(self):
     return {
@@ -271,6 +277,23 @@ class SingleuserProfiles(object):
     return None
 
   @classmethod
+  def apply_cpu_config(self, profile, cpu_types, pod):
+    gpu_count = profile.get('gpu', 0)
+    node_tolerations = []
+    node_affinity = {}
+    notebook_container = [container for container in pod.spec.containers if container.name == 'notebook'][0]
+
+    # If there are no GPUs in the cluster, or the user isn't requesting one, apply the cpu_type soft affinity
+    if (int(gpu_count) == 0) or (_GPU_KEY not in notebook_container.resources.requests):
+        # There may be multiple cpu_type options, apply them all the same way it's done for gpu_types
+        for cpu_type in cpu_types:
+            node_affinity = {**cpu_type.get('node_affinity', {}), **node_affinity}
+
+    self.apply_pod_schedulers(node_tolerations, node_affinity, pod)
+
+    return None
+
+  @classmethod
   def generate_volume_path(self, mountPath, default_mount_path, volume_name):
     if (mountPath):
       if (os.path.isabs(mountPath)):
@@ -293,7 +316,7 @@ class SingleuserProfiles(object):
     
 
   @classmethod
-  def apply_pod_profile(self, username, pod, profile, gpu_types, default_mount_path, gpu_mode=None, selected_gpu_type="ALL"):
+  def apply_pod_profile(self, username, pod, profile, gpu_types, cpu_types, default_mount_path, gpu_mode=None, selected_gpu_type="ALL"):
     api_client = kubernetes.client.ApiClient()
 
     pod.metadata.labels['jupyterhub.opendatahub.io/user'] = escape(username)
@@ -365,6 +388,7 @@ class SingleuserProfiles(object):
         env.append(V1EnvVar(_JUPYTERHUB_USER_NAME_ENV, username))
 
     self.apply_gpu_config(gpu_mode, profile, gpu_types, pod, selected_gpu_type)
+    self.apply_cpu_config(profile, cpu_types, pod)
 
     node_tolerations = profile.get('node_tolerations', [])
     node_affinity = profile.get('node_affinity', {})


### PR DESCRIPTION
This commit adds in a soft anti-affinity for nodes tagged as GPU
nodes by the Nvidia GPU operator. When creating a pod that doesn't
request any GPUs, it will have an affinity added that avoids GPU
tagged nodes if possible. If there are no available nodes that
satisfy that requirement, it will allow scheduling onto the GPU
nodes to avoid a scheduling failure.

To test, apply this fix and then observe the resulting pod spec for GPU and non-GPU pods. Non-GPU pods should have:
```
        'preferredDuringSchedulingIgnoredDuringExecution': [{
          'preference': {'matchExpressions': [{
            'key': 'nvidia.com/gpu.present', 'operator': 'NotIn', 'values': ['true']}]},
          'weight': 1}]
```

See also https://github.com/opendatahub-io/jupyterhub-odh/pull/135 and https://github.com/opendatahub-io/odh-manifests/pull/556 for previous attempts at this feature

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-3074
- [ ] The Jira story is acked
- [ ] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)
