### PR TITLE
[UPSTREAM] Use JupyterHub SA to access GPU metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
+.idea/

--- a/jupyterhub_singleuser_profiles/openshift.py
+++ b/jupyterhub_singleuser_profiles/openshift.py
@@ -166,13 +166,14 @@ class OpenShift(object):
     return memory
 
   def get_openshift_prometheus_token(self):
-    service_account = self.api_client.read_namespaced_service_account("prometheus-k8s", "openshift-monitoring")
-    token_secret_name = [s for s in service_account.secrets if 'token' in s.name][0].name
-    secret = self.api_client.read_namespaced_secret(token_secret_name, "openshift-monitoring")
-    # get base64 encoded Prometheus token from the secret
-    prometheus_token = secret.data.get('token')
-    prometheus_token_str = str(base64.b64decode(prometheus_token.strip()), 'utf-8')
+    file_path = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+    prometheus_token_str = ""
 
+    if os.path.isfile(file_path):
+       with open(file_path) as file:
+           prometheus_token_str = file.read().replace('\n', '')
+    else:
+       _LOGGER.error("Unable to get token for Prometheus")
     return prometheus_token_str
 
   def get_prometheus_url(self):


### PR DESCRIPTION

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-4820
- [ ] The Jira story is acked
- [x] Live Build :  quay.io/modh/rhods-operator-live-bundle:1.15.0-rhods-4820 


Testing Steps:
1. Deploy Live Build on 4.11 cluster
2. Deploy GPU add-on
3. Spawn a notebook with GPU